### PR TITLE
Make authenticated decryption work with keys longer than 32 octets

### DIFF
--- a/src/jwe.c
+++ b/src/jwe.c
@@ -1919,7 +1919,7 @@ static int r_jwe_compute_hmac_tag(jwe_t * jwe, unsigned char * ciphertext, size_
     memcpy(compute_hmac+hmac_size, al, 8);
     hmac_size += 8;
 
-    if (!(res = gnutls_hmac_fast(mac, jwe->key, 16, compute_hmac, hmac_size, tag))) {
+    if (!(res = gnutls_hmac_fast(mac, jwe->key, jwe->key_len/2, compute_hmac, hmac_size, tag))) {
       *tag_len = gnutls_hmac_get_len(mac)/2;
       ret = RHN_OK;
     } else {


### PR DESCRIPTION
We just switched from cjose to rhonabwy and our JWE tests didn't work any more.
I then compared your implementation with the implementation of cjose and found the difference in the calculation of the authentication tag.
In your implementation the key length is fixed to 16 bytes, in the implentation of cjose the key length is calculated by dividing the original key length by two.
This behaviour matches the examples found here:
- https://datatracker.ietf.org/doc/html/rfc7518#section-5.2.3
- https://datatracker.ietf.org/doc/html/rfc7518#section-5.2.4
- https://datatracker.ietf.org/doc/html/rfc7518#section-5.2.5

With this patch our JWE tests do work again.