### PR TITLE
Fix several -Werror=sign-conversion warnings

### DIFF
--- a/src/jwk.c
+++ b/src/jwk.c
@@ -2708,7 +2708,7 @@ char * r_jwk_thumbprint(jwk_t * jwk, int hash, int x5u_flags) {
         key_dump = json_dumps(key_members, JSON_COMPACT|JSON_SORT_KEYS);
         if (key_dump != NULL) {
           if (!gnutls_hash_fast(alg, key_dump, o_strlen(key_dump), jwk_hash)) {
-            if (o_base64url_encode(jwk_hash, gnutls_hash_get_len(alg), jwk_hash_b64, &jwk_hash_b64_len)) {
+            if (o_base64url_encode(jwk_hash, (unsigned)gnutls_hash_get_len(alg), jwk_hash_b64, &jwk_hash_b64_len)) {
               thumb = o_strndup((const char *)jwk_hash_b64, jwk_hash_b64_len);
             } else {
               y_log_message(Y_LOG_LEVEL_ERROR, "r_jwk_thumbprint, error o_base64url_encode");

--- a/src/jws.c
+++ b/src/jws.c
@@ -211,7 +211,7 @@ static unsigned char * r_jws_sign_hmac(jws_t * jws, jwk_t * jwk) {
   }
 
   if (alg != GNUTLS_DIG_NULL) {
-    sig_len = gnutls_hmac_get_len(alg);
+    sig_len = (unsigned)gnutls_hmac_get_len(alg);
     sig = o_malloc(sig_len);
 
     key_len = o_strlen(r_jwk_get_property_str(jwk, "k"));

--- a/src/jwt.c
+++ b/src/jwt.c
@@ -963,7 +963,7 @@ int r_jwt_generate_enc_iv(jwt_t * jwt) {
   int ret;
 
   if (jwt != NULL && jwt->enc != R_JWA_ENC_UNKNOWN) {
-    jwt->iv_len = gnutls_cipher_get_iv_size(_r_get_alg_from_enc(jwt->enc));
+    jwt->iv_len = (unsigned)gnutls_cipher_get_iv_size(_r_get_alg_from_enc(jwt->enc));
     o_free(jwt->iv);
     jwt->iv = NULL;
     if (jwt->iv_len) {


### PR DESCRIPTION
In several places, jwe.c stores a (signed int) gnutls returned value into an unsigned size_t. This would cause warning like the following:


jwe.c:1872:53: error: conversion to 'size_t {aka long unsigned int}'
  from 'int' may change the sign of the result [-Werror=sign-conversion]


I have reviewed each location, and the gnutls lib returns the size of something, in every case, and never a negative number. This means it's safe to cast these return values to (unsigned). The functions returning int are:

 - gnutls_cipher_get_iv_size
 - gnutls_cipher_get_tag_size
 - gnutls_hmac_get_len
 - gnutls_cipher_get_block_size
 - gnutls_hash_get_len

This commit adds a cast of (unsigned) to the return value from these function, which avoids the -Werror=sign-conversion warnings