### PR TITLE
Bugfix/siva.cbces - Fixup the K for AxxxCBC + ECDH-ES based JWEs

### DIFF
--- a/src/jwe.c
+++ b/src/jwe.c
@@ -695,6 +695,8 @@ static int _r_concat_kdf(jwe_t * jwe, jwa_alg alg, const gnutls_datum_t * Z, gnu
              * apu = r_jwe_get_header_str_value(jwe, "apu"),
              * apv = r_jwe_get_header_str_value(jwe, "apv");
   size_t alg_id_len = o_strlen(alg_id), key_data_len = 0;
+  size_t derived_key_len = _r_get_key_size(jwe->enc);
+  size_t current_key_len = 0;
 
   kdf->data = NULL;
   kdf->size = 0;
@@ -795,9 +797,6 @@ static int _r_concat_kdf(jwe_t * jwe, jwa_alg alg, const gnutls_datum_t * Z, gnu
     kdf->data[kdf->size+3] = (unsigned char)(key_data_len) & 0xFF;
     kdf->size += 4;
 
-    size_t derived_key_len = _r_get_key_size(jwe->enc);
-    size_t current_key_len = 0;
-
     for (uint8_t i = 1; ; i++) {
       memset(kdf->data+3, i, 1);
       if (gnutls_hash_fast(GNUTLS_DIG_SHA256, kdf->data, kdf->size, derived_key+current_key_len) != GNUTLS_E_SUCCESS) {
@@ -809,6 +808,9 @@ static int _r_concat_kdf(jwe_t * jwe, jwa_alg alg, const gnutls_datum_t * Z, gnu
       if (alg != R_JWA_ALG_ECDH_ES || current_key_len >= derived_key_len) {
         break;
       }
+    }
+    if (ret != RHN_OK) {
+      break;
     }
 
   } while (0);


### PR DESCRIPTION
1. fix the K - Please refer https://github.com/babelouest/rhonabwy/issues/28 for full details

2. display nested jwt header (for jwe)
```
{
  "alg": "ECDH-ES",
  "cty": "JWT",
  "enc": "A192CBC-HS384",
  "epk": {
    "crv": "P-256",
    "kty": "EC",
    "x": "UcL8hgW6OTkqFvKS-XEiO-zwQqdqdj8myxOkVJ9f_n8",
    "y": "yDaZ0U9XD6oGzkXRnFJVWenF8sthhcTBIzSdntLMxfU"
  },
  "kid": "ExUMY91J9atex-1Ai5vbu6qJ4aAGq0RMQxo__QyZV4k",
  "typ": "JWT"
}
{
  "alg": "ES512",
  "kid": "HSnBqAC6TJsmCntBQrgp_BpCWZSoxygedxeE7b2SBrA",
  "typ": "JWT"
}
{
  "iat": 1516239022,
  "name": "JohnDoe",
  "sub": "jdoe@example.com"
}
```